### PR TITLE
Update docs to extend docker section

### DIFF
--- a/book/src/docker.md
+++ b/book/src/docker.md
@@ -17,3 +17,9 @@ $ docker run lighthouse lighthouse --help
 
 _Note: the first `lighthouse` is the name of the tag we created earlier. The
 second `lighthouse` refers to the binary installed in the image._
+
+To start a beacon node with a persistent data directory and access to the JSON-RPC API on the host at port 5052 run the image with:
+
+```bash
+$ docker run --name=lighthouse -v $HOME/lighthouse-data:/root/.lighthouse -p 127.0.0.1:5052:5052 lighthouse lighthouse beacon_node --http-address=0.0.0.0 --http-port=5052 --http
+```


### PR DESCRIPTION
This small PR adds an example of how to run a lighthouse beacon node via docker with a persistent data directory and access to the JSON RPC API on the host.